### PR TITLE
Prevent staging of duplicate files (#4403)

### DIFF
--- a/src/objects/core/zcl_abapgit_file_status.clas.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.abap
@@ -333,6 +333,9 @@ CLASS ZCL_ABAPGIT_FILE_STATUS IMPLEMENTATION.
       READ TABLE it_local ASSIGNING <ls_local>
         WITH KEY file-filename = <ls_remote>-filename.
       IF sy-subrc = 0 AND <ls_local>-file-sha1 = <ls_remote>-sha1.
+        <ls_result>-match = abap_false.
+        <ls_result>-lstate = zif_abapgit_definitions=>c_state-deleted.
+        <ls_result>-rstate = zif_abapgit_definitions=>c_state-unchanged.
         <ls_result>-packmove = abap_true.
       ELSEIF sy-subrc = 4.
         " Check if file existed before and was deleted locally

--- a/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
+++ b/src/objects/core/zcl_abapgit_file_status.clas.testclasses.abap
@@ -783,13 +783,13 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
 
     DATA:
       ls_line TYPE zif_abapgit_definitions=>ty_result,
-      lv_act  TYPE c LENGTH 3,
-      lv_exp  TYPE c LENGTH 3.
+      lv_act  TYPE c LENGTH 4,
+      lv_exp  TYPE c LENGTH 4.
 
     mo_helper->add_local(
       iv_path     = '/'
       iv_filename = '.abapgit.xml'
-      iv_sha1     = '1017'  ).
+      iv_sha1     = '1017' ).
     mo_helper->add_local(
       iv_path     = '/src/'
       iv_filename = 'ztest_created_locally.prog.abap'
@@ -842,6 +842,14 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_path     = '/src/'
       iv_filename = 'package.devc.xml'
       iv_sha1     = '1027' ).
+    mo_helper->add_local(
+      iv_path     = '/src/sub/'
+      iv_filename = 'ztest_move_package.prog.xml'
+      iv_sha1     = '1040' ).
+    mo_helper->add_local(
+      iv_path     = '/src/sub/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '1041' ).
 
     mo_helper->add_remote(
       iv_path     = '/'
@@ -903,6 +911,14 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_path     = '/src/'
       iv_filename = 'ztest_modified_remotely.prog.xml'
       iv_sha1     = '1031' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/'
+      iv_filename = 'ztest_move_package.prog.xml'
+      iv_sha1     = '1040' ).
+    mo_helper->add_remote(
+      iv_path     = '/src/sub/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '1041' ).
 
     mo_helper->add_state(
       iv_path     = '/'
@@ -968,16 +984,25 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
       iv_path     = '/src/'
       iv_filename = 'ztest_mod_del.prog.xml'
       iv_sha1     = '1005' ).
+    mo_helper->add_state(
+      iv_path     = '/src/sub/'
+      iv_filename = 'ztest_move_package.prog.xml'
+      iv_sha1     = '1040' ).
+    mo_helper->add_state(
+      iv_path     = '/src/sub/'
+      iv_filename = 'package.devc.xml'
+      iv_sha1     = '1041' ).
 
     mo_result = mo_helper->run( ).
 
-    mo_result->assert_lines( 21 ).
+    mo_result->assert_lines( 24 ).
 
-    DO 21 TIMES.
+    DO 24 TIMES.
       ls_line = mo_result->get_line( sy-index ).
       lv_act+0(1) = ls_line-match.
       lv_act+1(1) = ls_line-lstate.
       lv_act+2(1) = ls_line-rstate.
+      lv_act+3(1) = ls_line-packmove.
       CASE sy-index.
         WHEN 1.
           lv_exp = 'X  '.
@@ -1003,6 +1028,12 @@ CLASS ltcl_calculate_status IMPLEMENTATION.
           lv_exp = ' M '.
         WHEN 20 OR 21.
           lv_exp = '  M'.
+        WHEN 22.
+          lv_exp = ' D X'.
+        WHEN 23.
+          lv_exp = 'X   '.
+        WHEN 24.
+          lv_exp = ' A X'.
       ENDCASE.
 
       cl_abap_unit_assert=>assert_equals(

--- a/src/ui/zcl_abapgit_gui_page_stage.clas.abap
+++ b/src/ui/zcl_abapgit_gui_page_stage.clas.abap
@@ -46,6 +46,11 @@ CLASS zcl_abapgit_gui_page_stage DEFINITION
     DATA mv_seed TYPE string .             " Unique page id to bind JS sessionStorage
     DATA mv_filter_value TYPE string .
 
+    METHODS check_selected
+      IMPORTING
+        !io_files TYPE REF TO zcl_abapgit_string_map
+      RAISING
+        zcx_abapgit_exception .
     METHODS find_changed_by
       IMPORTING
         !it_files            TYPE zif_abapgit_definitions=>ty_stage_files
@@ -131,7 +136,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
+CLASS zcl_abapgit_gui_page_stage IMPLEMENTATION.
 
 
   METHOD build_menu.
@@ -147,6 +152,43 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
                     iv_typ = zif_abapgit_html=>c_action_type-onclick
                     iv_id  = |patchBtn| ).
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD check_selected.
+
+    DATA:
+      ls_file    TYPE zif_abapgit_definitions=>ty_file,
+      lv_pattern TYPE string,
+      lv_msg     TYPE string.
+
+    FIELD-SYMBOLS:
+      <ls_item>     LIKE LINE OF io_files->mt_entries,
+      <ls_item_chk> LIKE LINE OF io_files->mt_entries.
+
+    " Check all added files if the exist in different paths (packages) without being removed
+    LOOP AT io_files->mt_entries ASSIGNING <ls_item> WHERE v = zif_abapgit_definitions=>c_method-add.
+
+      zcl_abapgit_path=>split_file_location(
+        EXPORTING
+          iv_fullpath = to_lower( <ls_item>-k )
+        IMPORTING
+          ev_path     = ls_file-path
+          ev_filename = ls_file-filename ).
+
+      lv_pattern = '*/' && to_upper( ls_file-filename ).
+      REPLACE ALL OCCURRENCES OF '#' IN lv_pattern WITH '##'. " for CP
+
+      LOOP AT io_files->mt_entries ASSIGNING <ls_item_chk>
+        WHERE k CP lv_pattern AND k <> <ls_item>-k AND v <> zif_abapgit_definitions=>c_method-rm.
+
+        lv_msg = |In order to add { to_lower( <ls_item>-k ) }, | &&
+                 |you have to remove { to_lower( <ls_item_chk>-k ) }|.
+        zcx_abapgit_exception=>raise( lv_msg ).
+
+      ENDLOOP.
+    ENDLOOP.
 
   ENDMETHOD.
 
@@ -735,6 +777,8 @@ CLASS ZCL_ABAPGIT_GUI_PAGE_STAGE IMPLEMENTATION.
     IF lo_files->size( ) = 0.
       zcx_abapgit_exception=>raise( 'process_stage_list: empty list' ).
     ENDIF.
+
+    check_selected( lo_files ).
 
     CREATE OBJECT ro_stage.
 


### PR DESCRIPTION
* Prevent staging of duplicate files

Since objects cannot exist in multiple packages, the staging page is now checking the selected files to prevent the resulting repo from containing an object multiple times.

If an object is moved to another SAP package and the corresponding files are seleted to be added to the repo (for the new package), then the files must also be removed from the repo (from the old package). If not, an error is raised.

* Remove other changes

* Update file status

* Extend unit test

Co-authored-by: Lars Hvam <larshp@hotmail.com>